### PR TITLE
change from requiring standard URL to requiring standard or alternate

### DIFF
--- a/KeePassRPC/KeePassRPCService.cs
+++ b/KeePassRPC/KeePassRPCService.cs
@@ -2142,9 +2142,16 @@ namespace KeePassRPC
                         if (db.RecycleBinUuid.EqualsValue(pwe.ParentGroup.Uuid))
                             continue; // ignore if it's in the recycle bin
 
-                        if (pwe.Strings.Exists("Hide from KeeFox") || pwe.Strings.Exists("Hide from KPRPC") || string.IsNullOrEmpty(pwe.Strings.ReadSafe("URL")))
-                            continue; // entries must have a standard URL entry
-
+                        if (pwe.Strings.Exists("Hide from KeeFox") ||
+                            pwe.Strings.Exists("Hide from KPRPC") ||
+                            (pwe.Strings.GetSafe(PwDefs.UrlField).Length == 0 &&
+                            !pwe.Strings.Exists("KeeFox URL Regex match") &&
+                            !pwe.Strings.Exists("KPRPC URL Regex match") &&
+                            !pwe.Strings.Exists("Alternative URLs") &&
+                            !pwe.Strings.Exists("KPRPC Alternative URLs")))
+                            continue; 
+                            // entries must have a standard or alternate URL entry
+                      
                         bool allowHostnameOnlyMatch = true;
                         if (pwe.Strings.Exists("KPRPC Block hostname-only match"))
                         {


### PR DESCRIPTION
Chris,

Is there a reason that you have to have something in the standard URL field in order for KeeFox to find matching URL's? I have some entries that I would like to leave the standard URL field blank and only use the Alternative URL field provided by KeePass RPC. This is a patch to make that happen.
