### PR TITLE
ignore entries in subgroups of recycle bin

### DIFF
--- a/KeePassRPC/KeePassRPCService.cs
+++ b/KeePassRPC/KeePassRPCService.cs
@@ -1623,7 +1623,18 @@ namespace KeePassRPC
 
             foreach (PwEntry pwe in output)
             {
-                if (host.Database.RecycleBinUuid.EqualsValue(pwe.ParentGroup.Uuid))
+                bool entryInRecycleBin = false;
+                PwGroup parent = pwe.ParentGroup;
+                while (parent != null)
+                {
+                    if (host.Database.RecycleBinUuid.EqualsValue(parent.Uuid))
+                    {
+                        entryInRecycleBin = true;
+                        break;
+                    }
+                    parent = parent.ParentGroup;
+                }
+                if (entryInRecycleBin)
                     continue; // ignore if it's in the recycle bin
 
                 if (string.IsNullOrEmpty(pwe.Strings.ReadSafe("URL")))
@@ -1691,7 +1702,18 @@ namespace KeePassRPC
 
                 foreach (PwEntry pwe in output)
                 {
-                    if (pwd.RecycleBinUuid.EqualsValue(pwe.ParentGroup.Uuid))
+                    bool entryInRecycleBin = false;
+                    PwGroup parent = pwe.ParentGroup;
+                    while (parent != null)
+                    {
+                        if (host.Database.RecycleBinUuid.EqualsValue(parent.Uuid))
+                        {
+                            entryInRecycleBin = true;
+                            break;
+                        }
+                        parent = parent.ParentGroup;
+                    }
+                    if (entryInRecycleBin)
                         continue; // ignore if it's in the recycle bin
 
                     if (string.IsNullOrEmpty(pwe.Strings.ReadSafe("URL")))
@@ -2067,7 +2089,19 @@ namespace KeePassRPC
                     // Search every entry in the DB
                     foreach (PwEntry pwe in output)
                     {
-                        if (db.RecycleBinUuid.EqualsValue(pwe.ParentGroup.Uuid))
+
+                        bool entryInRecycleBin = false;
+                        PwGroup parent = pwe.ParentGroup;
+                        while (parent != null)
+                        {
+                            if (host.Database.RecycleBinUuid.EqualsValue(parent.Uuid))
+                            {
+                                entryInRecycleBin = true;
+                                break;
+                            }
+                            parent = parent.ParentGroup;
+                        }
+                        if (entryInRecycleBin)
                             continue; // ignore if it's in the recycle bin
 
                         if (string.IsNullOrEmpty(pwe.Strings.ReadSafe("URL")))


### PR DESCRIPTION
If you delete an entire group (move it to recycle bin), then the entries in that group are not ignored when finding matching passwords. Only entries that have Recycle Bin as the immediate parent group are ignored. 

This patch searches all parent groups to determine if an entry is in the recycle bin instead of just checking the immediate parent group.
