### PR TITLE
Quick fix for Issue #169

### DIFF
--- a/KeePassRPC/KeePassRPCServer.cs
+++ b/KeePassRPC/KeePassRPCServer.cs
@@ -62,8 +62,8 @@ namespace KeePassRPC
         private bool _useSSL = true;
         private string pkcs12_password = "private"; // Really doesn't matter, but required for Mono
 		private AutoResetEvent wait_event = null;
-		private List<Thread> activeClientThreads;
-		
+        private List<Thread> activeClientThreads;
+
         /// <summary>
         /// Gets a value indicating whether this server is listening for connection requests from clients.
         /// </summary>
@@ -79,11 +79,11 @@ namespace KeePassRPC
         /// Terminates this server.
         /// </summary>
         public void Terminate()
-        {			
+        {
             this._tcpListener.Stop();
-			foreach (var thread in activeClientThreads.ToArray()) {
-				thread.Interrupt();
-			}
+            foreach (var thread in activeClientThreads.ToArray()) {
+                thread.Interrupt();
+            }
 			// KRB - there appears to be a race condition here (at least under Mono).
 			// The above Stop will signal AcceptTcpClient() in ListenForClients() to exit.
 			// However, the thread may not exit until AFTER the main KeePass program
@@ -112,7 +112,7 @@ namespace KeePassRPC
             if (keePassRPCPlugin.logger != null) keePassRPCPlugin.logger.WriteLine("Starting KPRPCServer");
             Service = service;
             KeePassRPCPlugin = keePassRPCPlugin;
-			activeClientThreads = new List<Thread>();
+            activeClientThreads = new List<Thread>();
 
             if (_useSSL)
             {
@@ -215,7 +215,7 @@ namespace KeePassRPC
             {
                 this._tcpListener =  new TcpListener(IPAddress.Loopback, port);
                 this._listenThread = new Thread(new ThreadStart(ListenForClients));
-				this._listenThread.Name = "KeePassRPCServer._listenThread";
+                this._listenThread.Name = "KeePassRPCServer._listenThread";
                 this._listenThread.Start();
                 this._isListening = true; // just in case the main thread checks
                     // for successful startup before the thread has got going.
@@ -234,8 +234,8 @@ namespace KeePassRPC
         {
             bool tryToListen = true;
             long lastListenAttempt = 0;
-			this.wait_event = new AutoResetEvent(false);
-			int connectionThreadCount = 0;
+            this.wait_event = new AutoResetEvent(false);
+            int connectionThreadCount = 0;
 
             // Keep listening even if the connection drops out occasionally
             while (tryToListen)
@@ -256,10 +256,10 @@ namespace KeePassRPC
                         //create a thread to handle communication with connected client
                         Thread clientThread = new Thread(
                             new ParameterizedThreadStart(HandleClientComm));
-						clientThread.Name = string.Format("KeePassRPCServer - clientThread{0}",
-						                                  connectionThreadCount++);
+                        clientThread.Name = string.Format("KeePassRPCServer - clientThread{0}",
+                                                          connectionThreadCount++);
                         clientThread.Start(client);
-						activeClientThreads.Add(clientThread);
+                        activeClientThreads.Add(clientThread);
                     }
                 }
                 catch (Exception ex)
@@ -465,7 +465,7 @@ namespace KeePassRPC
                     clientStream.Close();
 				}
             }
-			activeClientThreads.Remove(Thread.CurrentThread);
+            activeClientThreads.Remove(Thread.CurrentThread);
         }
 
         /// <summary>


### PR DESCRIPTION
I added a private member variable to track all of the threads that are running and interrupt those threads when KeePassRPCServer.Terminate() is called. This seems to make it shutdown cleanly. Still need to test in real life.
