### PR TITLE
Add UI for showing version of selected locations/files.

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/options.js
+++ b/Firefox addon/KeeFox/chrome/content/options.js
@@ -22,6 +22,9 @@ function onLoad(){
       ],
       ['title','label','tooltiptext','accesskey','value']);
 
+    validateFileLocation("keePassInstalledLocation", "KeePass.exe");
+    validateFileLocation("keePassRPCInstalledLocation", "KeePassRPC.plgx");
+    validateFileLocation("monoLocation");
 }
 
 function onsyncfrompreferenceMatchSelected()
@@ -152,6 +155,7 @@ function browseForKeePassLocation(currentLocationPath)
                                      Components.interfaces.nsIFilePicker.modeGetFolder, 'selectKeePassLocation', 'NoFilter');
     document.getElementById("keePassInstalledLocation").value = location;
     document.getElementById("KeeFox-pref-keePassInstalledLocation").value = location;
+    validateFileLocation("keePassInstalledLocation", "KeePass.exe");
 }
 
 function browseForKPRPCLocation(currentLocationPath)
@@ -160,6 +164,7 @@ function browseForKPRPCLocation(currentLocationPath)
                                      Components.interfaces.nsIFilePicker.modeGetFolder, 'selectKeePassLocation', 'NoFilter');
     document.getElementById("keePassRPCInstalledLocation").value = location;
     document.getElementById("KeeFox-pref-keePassRPCInstalledLocation").value = location;
+    validateFileLocation("keePassRPCInstalledLocation", "KeePassRPC.plgx");
 }
 
 function browseForMonoLocation(currentLocationPath)
@@ -168,6 +173,7 @@ function browseForMonoLocation(currentLocationPath)
                                      Components.interfaces.nsIFilePicker.modeOpen, 'selectMonoLocation', 'NoFilter');
     document.getElementById("monoLocation").value = location;
     document.getElementById("KeeFox-pref-monoLocation").value = location;
+    validateFileLocation("monoLocation");
 }
 
 function browseForDefaultKDBXLocation(currentLocationPath)
@@ -228,4 +234,30 @@ function openSiteConfig()
     onOK,
     onCancel,
     null);
+}
+
+function validateFileLocation(id, fileName)
+{
+    var location = document.getElementById(id).value;
+    var file = Components.classes["@mozilla.org/file/local;1"].
+        createInstance(Components.interfaces.nsILocalFile);
+    var stausLabel = document.getElementById("lab-" + id + "Status");
+    if (location && location.length > 0) {
+      file.initWithPath(location);
+      if (typeof(fileName) !== "undefined")
+        file.append(fileName);
+      if (file.exists()) {
+          // TODO: Check and display version
+          stausLabel.value = "Found %1$S version %2$S".replace("%1$S", fileName);
+      } else {
+          stausLabel.value = "Could not find KeePass.exe at this location";
+          // TODO: Make text red for indicating error.
+      }
+    } else {
+        // TODO: show platform specific messages
+        if (id == "monoLocation" /* && isWindows */)
+          stausLabel.value = "Mono is not required on Windows.";
+        else
+          stausLabel.value = "????";
+    }
 }

--- a/Firefox addon/KeeFox/chrome/content/options.xul
+++ b/Firefox addon/KeeFox/chrome/content/options.xul
@@ -217,22 +217,25 @@
         <tabpanel>
           <vbox align="left">
             <label id="lab-keePassRPCInstalledLocation" control="keePassRPCInstalledLocation" value="%-KeeFox-pref-keePassRPCInstalledLocation.label-%:"/>            
-            <hbox class="itemEnd">
+            <hbox>
               <textbox preference="KeeFox-pref-keePassRPCInstalledLocation" id="keePassRPCInstalledLocation" maxlength="255" size="80" />
               <button id="keePassRPCInstalledLocationBrowseButton" label="%-KeeFox-browse.label-%..." oncommand="browseForKPRPCLocation(document.getElementById('keePassRPCInstalledLocation').value);"/>
             </hbox>
-            
+            <label id="lab-keePassRPCInstalledLocationStatus" value="staus" class="itemEnd" />
+
             <label id="lab-keePassInstalledLocation" control="keePassInstalledLocation" value="%-KeeFox-pref-keePassInstalledLocation.label-%:"/>
-            <hbox class="itemEnd">
+            <hbox>
               <textbox preference="KeeFox-pref-keePassInstalledLocation" id="keePassInstalledLocation" maxlength="255" size="80" />
               <button id="keePassInstalledLocationBrowseButton" label="%-KeeFox-browse.label-%..." oncommand="browseForKeePassLocation(document.getElementById('keePassInstalledLocation').value);"/>
             </hbox>
-            
+            <label id="lab-keePassInstalledLocationStatus" value="staus" class="itemEnd" />
+
             <label id="lab-monoLocation" control="monoLocation" value="%-KeeFox-pref-monoLocation.label-%:"/>
-            <hbox class="itemEnd">
+            <hbox>
               <textbox preference="KeeFox-pref-monoLocation" id="monoLocation" maxlength="255" size="80" />
               <button id="monoLocationBrowseButton" label="%-KeeFox-browse.label-%..." oncommand="browseForMonoLocation(document.getElementById('monoLocation').value);"/>
             </hbox>
+            <label id="lab-monoLocationStatus" value="staus" class="itemEnd" />
 
             <checkbox id="keePassRememberInstalledLocation" preference="KeeFox-pref-keePassRememberInstalledLocation" label="%-KeeFox-pref-keePassRememberInstalledLocation.label-%" class="itemEnd" />
             <label id="lab-keePassLocation" control="keePassLocation" value="%-KeeFox-pref-keePassLocation.label-%:"/>


### PR DESCRIPTION
I got off on a tangent here, so I don't know if this would be useful or not. Now that I am sitting here trying to explain why I was doing this, I'm not really sure what I was thinking other than part of my motivation for this was that if there is a version incompatibility between KeeFox and KeePassRPC, then getting passwords in Thunderbird fails silently. This could help let users know what was wrong.

Here is my idea. I though it would be useful if you could see the versions of the .plgx file and so on that you select on the KeePass tab in KeeFox options. To really make this work, I would have to write a small .NET program to be included in the deps that gets the version of each file. And also add proper messages to the .properties files so that they can be translated.

Think this is worth perusing any further?
