### PR TITLE
Connect FormClosed event to handler

### DIFF
--- a/KeePassRPC/Forms/OptionsForm.Designer.cs
+++ b/KeePassRPC/Forms/OptionsForm.Designer.cs
@@ -466,6 +466,7 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "KeePassRPC (KeeFox) Options";
             this.Load += new System.EventHandler(this.OnFormLoad);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.OnFormClosed);
             ((System.ComponentModel.ISupportInitialize)(this.m_bannerImage)).EndInit();
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);


### PR DESCRIPTION
fixes luckyrat/KeeFox#254

The event handler that removes the dialog from the global window manager was just not wired up. Surprised no one ever noticed before.
