### PR TITLE
attempt to fix issue 262

### DIFF
--- a/Firefox addon/KeeFox/chrome/skin/keefox.css
+++ b/Firefox addon/KeeFox/chrome/skin/keefox.css
@@ -55,7 +55,7 @@ toolbar[iconsize="small"] toolbarbutton.login-found
 	list-style-image: url("chrome://keefox/skin/KeeOrange.png") !important;
 }
 
-.toolbarbutton-menubutton-button
+#KeeFox-Toolbar .toolbarbutton-menubutton-button
 {
 	-moz-box-orient: horizontal !important;
 	padding: 0px 3px !important;


### PR DESCRIPTION
I'm not sure why this rule is necessary, but if it still is, then making it specific to the KeeFox-Toolbar will fix the bookmarks-button issue.

Alternatively, this rule can be deleted now.
