### PR TITLE
fixed button never for this site

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/KFUI.js
+++ b/Firefox addon/KeeFox/chrome/content/KFUI.js
@@ -436,6 +436,7 @@ keefox_win.UI = {
                     {
                         let newConfig = keefox_org.config.applyMoreSpecificConfig(JSON.parse(JSON.stringify(keefox_org.config.getConfigDefinitionForURL(urlSchemeHostPort))),{"preventSaveNotification": true}); //TODO1.5: faster clone?
                         keefox_org.config.setConfigForURL(urlSchemeHostPort,newConfig);   
+                        keefox_org.config.save();
                     } finally
                     {
                         keefox_win.tabState.clearTabFormRecordingData();


### PR DESCRIPTION
Configuration just not have been saved after you click the button. I always wondered why i
everytime need to click this button again. After a browser close the site specific settings for this button are gone. Just added the save action on callback after setting the URL configs.
Sry for the weird commits, used wrong branch before fixing this bug.
