### PR TITLE
Fix #326 by removing redeclared variables

### DIFF
--- a/Firefox addon/KeeFox/modules/kprpcClient.js
+++ b/Firefox addon/KeeFox/modules/kprpcClient.js
@@ -1070,10 +1070,6 @@ kprpcClient.prototype.constructor = kprpcClient;
         t = tn;
         if (ourHmac !== hmac)
         {
-            var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-                                     .getService(Components.interfaces.nsIWindowMediator);
-            var window = wm.getMostRecentWindow("navigator:browser") ||
-                wm.getMostRecentWindow("mail:3pane");
             log.warn(window.keefox_org.locale.$STR("KeeFox-conn-setup-restart"));
             window.keefox_win.UI.showConnectionMessage(window.keefox_org.locale.$STR("KeeFox-conn-setup-restart") 
                 + " " + window.keefox_org.locale.$STR("KeeFox-conn-setup-retype-password"));


### PR DESCRIPTION
'wm' and 'window' were declared earlier using let, and re-declared here with the same values. Removing the second declarations fixes the "TypeError: redeclaration of let wm - kprpcClient.js:1073" error.

This seems to fix things for me, and running js -c on all the js files in the addon didn't show any other errors.
