### PR TITLE
Revert "Escape special regex chars in template strings."

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -302,8 +302,6 @@ var keeFoxDialogManager = {
                         protocols[aDialogType] = aDialogType.split("-")[0];
                         titles[aDialogType] = aStringBundle.GetStringFromName(aTitlePropertyName);
                         prompts[aDialogType] = aStringBundle.GetStringFromName(aPromptPropertyName);
-                        titles[aDialogType] = titles[aDialogType].replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
-                        prompts[aDialogType] = prompts[aDialogType].replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
                         // use null as a flag to indicate that there was only one
                         // placeholder and hostIsFirst and secondIsUserName are not applicable
                         hostIsFirst[aDialogType] = null;


### PR DESCRIPTION
Reverts luckyrat/KeeFox#344. It broke POP3. See #351.