### PR TITLE
Remove characters that don't need to be escaped.

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -300,7 +300,7 @@ var keeFoxDialogManager = {
                 {
                     if (aStringBundle != null)
                     {
-                        let regexChars = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g;
+                        let regexChars = /[\[\{\(\)\*\+\?\.\\\^\$\|]/g;
                         protocols[aDialogType] = aDialogType.split("-")[0];
                         titles[aDialogType] = aStringBundle.GetStringFromName(aTitlePropertyName);
                         prompts[aDialogType] = aStringBundle.GetStringFromName(aPromptPropertyName);


### PR DESCRIPTION
The escapaing of regex meta characters included characters that it should
not have, so translations that include these failed to match (like de-DE).
The list now includes only the 12 special characters desribed in
<http://www.regular-expressions.info/characters.html>

Fixes luckyrat/KeeFox#351