### PR TITLE
Add support for Google Calendar Provider extension in Thunderbird.

### DIFF
--- a/Firefox addon/KeeFox/chrome.manifest
+++ b/Firefox addon/KeeFox/chrome.manifest
@@ -7,6 +7,9 @@ overlay	chrome://global/content/commonDialog.xul chrome://keefox/content/protoco
 
 overlay chrome://messenger/content/messenger.xul chrome://keefox/content/panel.xul
 
+# This is for the "Provider for Google Calendar" extension in Thunderbird
+overlay chrome://gdata-provider/content/browserRequest.xul chrome://keefox/content/gdata-provider.xul
+
 skin keefox classic/1.0 chrome/skin/
 resource kfmod modules/
 

--- a/Firefox addon/KeeFox/chrome/content/gdata-provider.js
+++ b/Firefox addon/KeeFox/chrome/content/gdata-provider.js
@@ -1,0 +1,450 @@
+/*
+KeeFox - Allows Firefox to communicate with KeePass (via the KeePassRPC KeePass plugin)
+Copyright 2008-2013 Chris Tomlinson <keefox@christomlinson.name>
+
+gdata-provider.js
+Copyright 2015 David Lechner <david@lechnology.com>
+
+Based on commonDialog.js
+
+Hooks into the browser authentication dialog used by the "Provider for Google
+Calendar" extension for Thunderbird.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+"use strict";
+
+if (!Cc)
+    var Cc = Components.classes;
+if (!Ci)
+    var Ci = Components.interfaces;
+if (!Cu)
+    var Cu = Components.utils;
+
+Cu.import("resource://kfmod/KF.js");
+
+var keeFoxGDataProviderHelper = {
+
+    __gdataBundle : null, // String bundle for L10N
+    get _gdataBundle() {
+        if (!this.__gdataBundle) {
+            var bunService = Components.classes["@mozilla.org/intl/stringbundle;1"].
+                getService(Components.interfaces.nsIStringBundleService);
+            this.__gdataBundle = bunService.createBundle(
+                "chrome://gdata-provider/locale/gdata.properties");
+            if (!this.__gdataBundle)
+                throw "GData string bundle not present!";
+        }
+        return this.__gdataBundle;
+    },
+
+    dialogInit : function(e) {
+        window.removeEventListener("load", keeFoxGDataProviderHelper.dialogInit);
+
+        // None of the DOM listener functions seem to work on this embedded browser window,
+        // so we use a timer to keep trying until the page is loaded.
+
+        try {
+            var email = document.getElementById("requestFrame").contentDocument.getElementById("Email").value
+            keeFoxGDataProviderHelper.dialogInit2();
+        } catch (exception) {
+            window.setTimeout(keeFoxGDataProviderHelper.dialogInit, 100);
+        }
+    },
+
+    dialogInit2 : function(e) {
+        try {
+            keeFoxGDataProviderHelper.prepareFill();
+        } catch (exception) {
+            try {
+                keefox_org._KFLog.error(exception);
+            } catch (e) {
+                // don't want missing keefox.org object to break standard dialogs
+            }
+        }
+    },
+
+    realm: null,
+    host: null,
+    username: null,
+
+    prepareFill : function() {
+        keefox_org._KFLog.debug("gdata-provider prepareFill accepted");
+
+        var mustAutoSubmit = false;
+        var host = "", realm = "", username = "";
+
+        try {
+            var requestWindowDescription = this._gdataBundle.GetStringFromName("requestWindowDescription").split("%1$S");
+            keefox_org._KFLog.debug(requestWindowDescription);
+            var split = requestWindowDescription;
+            var description = document.getElementById("dialogMessage").innerHTML;
+            keefox_org._KFLog.debug(description);
+            username = description.replace(split[0], "").replace(split[1], "");
+            keefox_org._KFLog.debug(username);
+            host = username.split("@")[1];
+            keefox_org._KFLog.debug(host);
+        } catch (exception) {
+            keefox_org._KFLog.debug("Error while getting Email input element: " + exception);
+        }
+
+        // try to pick out the host from the full protocol, host and port
+        this.originalHost = host;
+        try {
+            var ioService = Components.classes["@mozilla.org/network/io-service;1"].
+                getService(Components.interfaces.nsIIOService);
+            var uri = ioService.newURI(host, null, null);
+            host = uri.host;
+        } catch (exception) {
+            if (keefox_org._KFLog.logSensitiveData)
+                keefox_org._KFLog.debug("Exception occured while trying to extract the host from this string: " + host + ". " + exception);
+            else
+                keefox_org._KFLog.debug("Exception occured while trying to extract the host from a string");
+        }
+
+        this.realm = realm;
+        this.host = host;
+        this.username = username;
+        this.mustAutoSubmit = mustAutoSubmit;
+
+        /* add ui elements to dialog */
+
+        // this box displays labels and also the list of entries when fetched
+        var box = document.getElementById("keefox-hbox");
+
+        var loadingPasswords = document.createElement("description");
+        loadingPasswords.setAttribute("id","keefox-autoauth-description");
+        var loadingPasswordsVBox = document.createElement("vbox");
+        loadingPasswordsVBox.setAttribute("id", "keefox-autoauth-box");
+        loadingPasswordsVBox.appendChild(loadingPasswords);
+        loadingPasswordsVBox.setAttribute("flex", "1");
+        loadingPasswordsVBox.setAttribute("pack", "center");
+        box.appendChild(loadingPasswordsVBox);
+
+        // button to lauch KeePass
+        var launchKeePassButton = document.createElement("button");
+        launchKeePassButton.setAttribute("id", "keefox-launch-kp-button");
+        launchKeePassButton.setAttribute("label", keefox_org.locale.$STR("launchKeePass.label"));
+        launchKeePassButton.addEventListener("command", function (event) { keefox_org.launchKeePass(''); }, false);
+        box.appendChild(launchKeePassButton);
+
+        this.prepareFillComplete = true;
+        this.updateDialog();
+    },
+
+    updateDialog : function() {
+        if (this.prepareFillComplete) {
+
+            var loadingPasswords = document.getElementById("keefox-autoauth-description");
+
+            // if we're not logged in to KeePass then we can't go on
+            if (!keefox_org._keeFoxStorage.get("KeePassRPCActive", false) ||
+                !keefox_org._keeFoxStorage.get("KeePassDatabaseOpen", false))
+            {
+                if (keeFoxGDataProviderHelper.updateTimer) {
+                  return;
+                }
+                loadingPasswords.setAttribute("value", keefox_org.locale.$STR("httpAuth.default"));
+                keeFoxGDataProviderHelper.updateTimer = setInterval(function() { keeFoxGDataProviderHelper.updateDialog(); }, 1000);
+                return;
+            }
+
+            if (keeFoxGDataProviderHelper.updateTimer) {
+              clearTimeout(keeFoxGDataProviderHelper.updateTimer);
+              delete keeFoxGDataProviderHelper.updateTimer;
+            }
+
+            loadingPasswords.setAttribute("value", keefox_org.locale.$STR("httpAuth.loadingPasswords") + "...");
+
+            var launchKeePassButton = document.getElementById("keefox-launch-kp-button");
+            launchKeePassButton.setAttribute("hidden", "true");
+
+            var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+                .getService(Components.interfaces.nsIWindowMediator);
+            var window = wm.getMostRecentWindow("navigator:browser") ||
+                wm.getMostRecentWindow("mail:3pane");
+
+            var dialogFindLoginStorage = {};
+            dialogFindLoginStorage.host = keeFoxGDataProviderHelper.host;
+            dialogFindLoginStorage.realm = keeFoxGDataProviderHelper.realm;
+            dialogFindLoginStorage.username = keeFoxGDataProviderHelper.username;
+            dialogFindLoginStorage.document = document;
+            dialogFindLoginStorage.mustAutoSubmit = keeFoxGDataProviderHelper.mustAutoSubmit;
+            // find all the logins
+            var requestId = keefox_org.findLogins(keeFoxGDataProviderHelper.originalHost,
+                null, keeFoxGDataProviderHelper.realm, null, null, null,
+                keeFoxGDataProviderHelper.username, keeFoxGDataProviderHelper.autoFill, dialogFindLoginStorage);
+        }
+    },
+
+    // fill in the dialog with the first matched login found and/or the list of all matched logins
+    autoFill : function(resultWrapper, dialogFindLoginStorage)
+    {
+        var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+                 .getService(Components.interfaces.nsIWindowMediator);
+        var window = wm.getMostRecentWindow("navigator:browser") ||
+                     wm.getMostRecentWindow("mail:3pane");
+        window.keefox_org._KFLog.info("callback fired!");
+
+        var foundLogins = null;
+        var convertedResult = [];
+
+        if ("result" in resultWrapper && resultWrapper.result !== false && resultWrapper.result != null)
+        {
+            let logins = resultWrapper.result;
+
+            for (var i in logins)
+            {
+                var kfl = window.keeFoxLoginInfo();
+                kfl.initFromEntry(logins[i]);
+                convertedResult.push(kfl);
+            }
+        }
+
+        if (convertedResult.length == 0)
+        {
+            // set "no passwords" message
+            document.getElementById("keefox-autoauth-description").setAttribute("value",keefox_org.locale.$STR("httpAuth.noMatches"));
+            return;
+        }
+
+        foundLogins = convertedResult;
+
+        // auto fill the dialog by default unless a preference or tab variable tells us otherwise
+        var autoFill = keefox_org._keeFoxExtension.prefs.getValue("autoFillDialogs",true);
+
+        // do not auto submit the dialog by default unless a preference or tab variable tells us otherwise
+        var autoSubmit = keefox_org._keeFoxExtension.prefs.getValue("autoSubmitDialogs",false);
+
+        // overwrite existing username by default unless a preference or tab variable tells us otherwise
+        var overWriteFieldsAutomatically = keefox_org._keeFoxExtension.prefs.getValue("overWriteFieldsAutomatically",true);
+
+        // this protects against infinite loops when the auto-submitted details are rejected
+        if (keefox_org._keeFoxExtension.prefs.has("lastProtocolAuthAttempt"))
+        {
+            if (Math.round(new Date().getTime() / 1000) - keefox_org._keeFoxExtension.prefs.get("lastProtocolAuthAttempt") <= 3)
+            {
+                autoFill = false;
+                autoSubmit = false;
+            }
+        }
+
+        if (dialogFindLoginStorage.document.getElementById("requestFrame").contentDocument.getElementById("Passwd").getAttribute("value") != ''
+            && !overWriteFieldsAutomatically)
+        {
+            autoFill = false;
+            autoSubmit = false;
+        }
+
+        if (keefox_org._KFLog.logSensitiveData)
+            keefox_org._KFLog.info("dialog: found " + foundLogins.length + " matching logins for '"+ dialogFindLoginStorage.realm + "' realm.");
+        else
+            keefox_org._KFLog.info("dialog: found " + foundLogins.length + " matching logins for a realm.");
+
+        if (foundLogins.length <= 0)
+            return;
+
+        var matchedLogins = [];
+        var showList;
+
+        // for every login
+        for (var i = 0; i < foundLogins.length; i++)
+        {
+            try {
+                var username = foundLogins[i].otherFields[foundLogins[i].usernameIndex];
+                var password = foundLogins[i].passwords[0];
+                var title = foundLogins[i].title;
+                var displayGroupPath = foundLogins[i].database.name + '/' + foundLogins[i].parentGroup.path;
+                matchedLogins.push({ 'username' : ((username !== undefined) ? username.value : ''),
+                    'password' : ((password !== undefined) ? password.value : ''),
+                    'host' : dialogFindLoginStorage.host,
+                    'title' : title,
+                    'displayGroupPath' : displayGroupPath,
+                    'alwaysAutoFill' : foundLogins[i].alwaysAutoFill,
+                    'neverAutoFill' : foundLogins[i].neverAutoFill,
+                    'alwaysAutoSubmit' : foundLogins[i].alwaysAutoSubmit,
+                    'neverAutoSubmit' : foundLogins[i].neverAutoSubmit,
+                    'httpRealm' : foundLogins[i].httpRealm,
+                    'priority' : foundLogins[i].priority,
+                    'matchAccuracy' : foundLogins[i].matchAccuracy,
+                    'uniqueID' : foundLogins[i].uniqueID
+                });
+                showList = true;
+
+            } catch (e) {
+                keefox_org._KFLog.error(e);
+            }
+        }
+
+        let bestMatch = 0;
+        let bestMatchScore = -1;
+
+        // create a drop down box with all matched logins
+        if (showList) {
+            var box = dialogFindLoginStorage.document.getElementById("keefox-autoauth-box");
+
+            var list = dialogFindLoginStorage.document.createElement("menulist");
+            list.setAttribute("id","autoauth-list");
+            var popup = dialogFindLoginStorage.document.createElement("menupopup");
+            var done = false;
+
+            for (var i = 0; i < matchedLogins.length; i++){
+                var item = dialogFindLoginStorage.document.createElement("menuitem");
+                item.setAttribute("label", keefox_org.locale.$STRF("matchedLogin.label",
+                    [matchedLogins[i].username, matchedLogins[i].host]));
+                item.setAttribute("tooltiptext", keefox_org.locale.$STRF("matchedLogin.tip",
+                    [matchedLogins[i].title, matchedLogins[i].displayGroupPath, matchedLogins[i].username]));
+                item.addEventListener("command", function (event) {
+                    keeFoxGDataProviderHelper.fill(this.username, this.password);
+                }, false);
+                item.username = matchedLogins[i].username;
+                item.password = matchedLogins[i].password;
+                popup.appendChild(item);
+
+                let loginMatchScore = keeFoxGDataProviderHelper.calculateRelevanceScore(matchedLogins[i], dialogFindLoginStorage);
+                if (loginMatchScore > bestMatchScore)
+                {
+                    bestMatchScore = loginMatchScore;
+                    bestMatch = i;
+                }
+            }
+
+            list.appendChild(popup);
+            // Remove all of the existing children
+            for (i = box.childNodes.length; i > 0; i--) {
+                box.removeChild(box.childNodes[0]);
+            }
+            box.appendChild(list);
+        }
+
+        if (matchedLogins[bestMatch] === undefined)
+            return;
+
+        if (matchedLogins[bestMatch].alwaysAutoFill)
+            autoFill = true;
+        if (matchedLogins[bestMatch].neverAutoFill)
+            autoFill = false;
+        if (matchedLogins[bestMatch].alwaysAutoSubmit)
+            autoSubmit = true;
+        if (matchedLogins[bestMatch].neverAutoSubmit)
+            autoSubmit = false;
+
+        if (autoFill)
+        {
+            // fill in the best matching login
+            keefox_org.metricsManager.pushEvent ("feature", "AutoFillDialog");
+            dialogFindLoginStorage.document.getElementById("requestFrame").contentDocument.getElementById("Email").value = matchedLogins[bestMatch].username;
+            dialogFindLoginStorage.document.getElementById("requestFrame").contentDocument.getElementById("Passwd").value = matchedLogins[bestMatch].password;
+        }
+        if (autoSubmit || dialogFindLoginStorage.mustAutoSubmit)
+        {
+            keefox_org.metricsManager.pushEvent ("feature", "AutoSubmitDialog");
+            Dialog.onButton0();
+            close();
+        }
+    },
+
+    calculateRelevanceScore: function (login, dialogFindLoginStorage) {
+        let score = 0;
+
+        // entry priorities provide a large score such that no other combination of relevance
+        // can override them
+        if (login.priority > 0)
+            score = 1000000000 - login.priority * 1000;
+
+        // We never know the exact URL but this can be matched on domain, hostname or hostname+port (once #358 is done)
+        score += login.matchAccuracy;
+
+        // A realm match is important (but there is no meaningful way of determining an "almost" match)
+        if (dialogFindLoginStorage.realm == login.httpRealm)
+            score += 50;
+
+        keefox_org._KFLog.info("Relevance for " + login.uniqueID + " is: " + score);
+        return score;
+    },
+
+    fill : function (username, password)
+    {
+        keefox_org.metricsManager.pushEvent ("feature", "MatchedSubmitDialog");
+        document.getElementById("requestFrame").contentDocument.getElementById("Email").value = username;
+        document.getElementById("requestFrame").contentDocument.getElementById("Passwd").value = password;
+        Dialog.onButton0();
+        close();
+    },
+
+    kfCommonDialogOnAccept : function ()
+    {
+        try
+        {
+            if (Dialog.args.promptType == "prompt" ||
+                Dialog.args.promptType == "promptUserAndPass" ||
+                Dialog.args.promptType == "promptPassword")
+            {
+                var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+                         .getService(Components.interfaces.nsIWindowMediator);
+                var parentWindow = wm.getMostRecentWindow("navigator:browser") ||
+                    wm.getMostRecentWindow("mail:3pane");
+                if (parentWindow.keefox_win._getSaveOnSubmitForSite(this.host))
+                    parentWindow.keefox_win.onHTTPAuthSubmit(parentWindow,
+                        document.getElementById("requestFrame").contentDocument.getElementById("Email").value,
+                        document.getElementById("requestFrame").contentDocument.getElementById("Passwd").value,
+                        this.host, this.realm);
+            }
+        } catch (ex)
+        {
+            // Do nothing (probably KeeFox has not initialised yet / properly)
+        }
+        Dialog.onButton0();
+    },
+
+    KPRPCAuthDialogClosing : function ()
+    {
+        //TODO:1.5: why doesn't this work? Is it needed?
+        //this.kprpcConnObserver.unregister();
+    }
+
+};
+
+function KPRPCConnectionObserver()
+{
+  this.register();
+}
+KPRPCConnectionObserver.prototype = {
+  observe: function(subject, topic, data) {
+     if (topic == "KPRPCConnectionClosed")
+     {
+        // Just close the dialog, SRP protocol will handle the cancellation process
+        // but we need to tell it why we are closing
+        var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+                         .getService(Components.interfaces.nsIWindowMediator);
+        var parentWindow = wm.getMostRecentWindow("navigator:browser") ||
+            wm.getMostRecentWindow("mail:3pane");
+        parentWindow.keefox_org.KeePassRPC.authPromptAborted = true;
+        close();
+     }
+  },
+  register: function() {
+    var observerService = Components.classes["@mozilla.org/observer-service;1"]
+                          .getService(Components.interfaces.nsIObserverService);
+    observerService.addObserver(this, "KPRPCConnectionClosed", false);
+  },
+  unregister: function() {
+    var observerService = Components.classes["@mozilla.org/observer-service;1"]
+                            .getService(Components.interfaces.nsIObserverService);
+    observerService.removeObserver(this, "KPRPCConnectionClosed");
+  }
+}
+
+window.addEventListener("load", keeFoxGDataProviderHelper.dialogInit, false);

--- a/Firefox addon/KeeFox/chrome/content/gdata-provider.xul
+++ b/Firefox addon/KeeFox/chrome/content/gdata-provider.xul
@@ -1,0 +1,10 @@
+<overlay id="KeeFox-GData-Provider-Overlay" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+
+  <script type="application/x-javascript" src="chrome://keefox/content/gdata-provider.js" />
+
+  <window id="browserRequest">
+    <hbox id="keefox-hbox" insertbefore="requestFrame">
+        <image src="chrome://keefox/skin/KeeFox24.png" align="center" style="padding-left:10px; padding-right:10px;" />
+    </hbox>
+  </window>
+</overlay>


### PR DESCRIPTION
This add a XUL overlay for the authentication dialog provided by the "Provider
for Google Calendar" extension in Thunderbird. The dialog uses an embedded
browser to load a web page, but the embedded browser does not provide the usual
DOM events, so the existing KeeFox web form filler does not work. So instead,
this treats it more like commonDialog that handles XUL dialogs. In fact, most
of the code is copied from commonDialog and modified to work with the gdata-provider
dialog.

