### PR TITLE
Use global setTimeout to prevent race condition when dialog is opened.

### DIFF
--- a/Firefox addon/KeeFox/modules/kprpcClient.js
+++ b/Firefox addon/KeeFox/modules/kprpcClient.js
@@ -121,14 +121,8 @@ kprpcClient.prototype.constructor = kprpcClient;
 
     this.KPRPCListener = function (signal)
     {
-        var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-                 .getService(Components.interfaces.nsIWindowMediator);
-        var window = wm.getMostRecentWindow("common-dialog") ||
-                     wm.getMostRecentWindow("navigator:browser") ||
-                     wm.getMostRecentWindow("mail:3pane");
-        
         // call this async so that json reader can get back to listening ASAP and prevent deadlocks
-        window.setTimeout(function () {
+        setTimeout(function () {
             var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
                      .getService(Components.interfaces.nsIWindowMediator);
             var window = wm.getMostRecentWindow("navigator:browser") ||
@@ -424,7 +418,7 @@ kprpcClient.prototype.constructor = kprpcClient;
             this.secretKey = this.getStoredKey();
 
             
-            window.setTimeout(function () {
+            setTimeout(function () {
                     
                 var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
                             .getService(Components.interfaces.nsIWindowMediator);
@@ -529,7 +523,7 @@ kprpcClient.prototype.constructor = kprpcClient;
             // store the key somewhere persistent (according to the security level rules)
             this.setStoredKey(this.srpClientInternals.I, this.getSecurityLevel(), this.srpClientInternals.key());
 
-            window.setTimeout(function () {
+            setTimeout(function () {
                     
                 var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
                             .getService(Components.interfaces.nsIWindowMediator);


### PR DESCRIPTION
It is possilble that during application startup, a dialog can open in the 50ms
between when these timers are set and the callback. It is probably longer than
50ms since the application is busy during startup, which increases the chance
of a problem.

Since we are bumping the minimum version to 22 (#356), we can now use the
setTimout from https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Timer.jsm

Since the timeout is no longer tied to window, it is free to callback even though
a modal dialog box opens.

Fixes #171