### PR TITLE
Don't escape regex characters for dialog titles.

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -273,7 +273,6 @@ var keeFoxDialogManager = {
                         protocols[aDialogType] = aDialogType.split("-")[0];
                         titles[aDialogType] = aStringBundle.GetStringFromName(aTitlePropertyName);
                         prompts[aDialogType] = aStringBundle.GetStringFromName(aPromptPropertyName);
-                        titles[aDialogType] = titles[aDialogType].replace(regexChars, "\\$&");
                         prompts[aDialogType] = prompts[aDialogType].replace(regexChars, "\\$&");
                         aHostPlaceholder = aHostPlaceholder.replace(regexChars, "\\$&");
                         // use null as a flag to indicate that there was only one


### PR DESCRIPTION
We don't use regex to match titles, just regular string ==. So, this caused
matches to fail if they contained regex characters, such as the `(` and `)`
introduced in Thunderbird 38.

Fixes luckyrat/KeeFox#388