### PR TITLE
Fix bad state with Auto-Fill/Submit combo boxes in KeePassRPC Entry panel.

### DIFF
--- a/KeePassRPC/Forms/KeeFoxEntryUserControl.cs
+++ b/KeePassRPC/Forms/KeeFoxEntryUserControl.cs
@@ -249,10 +249,7 @@ namespace KeePassRPC.Forms
                         changeBehaviourState(EntryBehaviour.Default);
                     break;
                 case "Never":
-                    if (comboBoxAutoSubmit.Text == "Never")
-                        changeBehaviourState(EntryBehaviour.NeverAutoSubmit);
-                    else
-                        changeBehaviourState(EntryBehaviour.NeverAutoFillNeverAutoSubmit);
+                    changeBehaviourState(EntryBehaviour.NeverAutoFillNeverAutoSubmit);
                     break;
                 case "Always":
                     if (comboBoxAutoSubmit.Text == "Never")


### PR DESCRIPTION
If Auto-Fill is never, then Auto-Submit must always be Never because there is
nothing filled in that can be automatically submitted.

Fixes luckyrat/KeeFox#363