### PR TITLE
TB pop bug

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -825,6 +825,8 @@ KPRPCConnectionObserver.prototype = {
   }
 }
 
+// uriUtils.js expects global variable "Logger"
+var Logger = keefox_org._KFLog;
 keeFoxDialogManager.scriptLoader.loadSubScript(
     "chrome://keefox/content/shared/uriUtils.js", keeFoxDialogManager);
 window.addEventListener("load", keeFoxDialogManager.dialogInit, false);

--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -313,7 +313,7 @@ var keeFoxDialogManager = {
                     this._imapBundleUsesStrings ? "imapEnterPasswordPromptTitle" : "5051",
                     this._imapBundleUsesStrings ? "imapEnterPasswordPrompt" : "5047",
                     "%S", null, null, true);
-                LoadDialogData(this._localMsgsBundle, "pop3", "pop3EnterPasswordPromptTitle",
+                LoadDialogData(this._localMsgsBundle, "pop", "pop3EnterPasswordPromptTitle",
                     "pop3EnterPasswordPrompt", "%2$S", null, "%1$S");
                 LoadDialogData(this._newsBundle, "nntp-1", "enterUserPassTitle",
                     "enterUserPassServer", "%S");


### PR DESCRIPTION
I noticed with v1.5.1.b1 that pop accounts are not working in TB. I found the reason is that I decided to use uriUtil.js in commonDialog.js. It looks like that before this, uriUtil.js was only used in windows/tabs in Firefox. As a result it used the Logger global variable from framescript/proxies/logger.js, which does not exist in the context of commonDialog.js. From what I can tell, even in Firefox with e10s enabled, commonDialog.js for HTTP auth and presumably others is called from the main application context and not the tab, so the Logger variable does not exist.

So, this is fixed for now, however, I would think the AMO reviewers are not going to like the name "Logger" for a global variable and suggest that your add a namespace.

The renaming of the scheme from pop3 to pop is just incidental. pop is technically correct, which is why I made the change, but it might have the potential to break things for people with exact matching. I imaging this is a relatively small number of users though.