### PR TITLE
Fix commonDialog string matching for some transations in Firefox 50+

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -413,6 +413,12 @@ var keeFoxDialogManager = {
                 if (currentRealmL10nPattern.indexOf("%2$S") > currentRealmL10nPattern.indexOf("%1$S"))
                     realmFirst = true;
 
+                // Due to https://bugzilla.mozilla.org/show_bug.cgi?id=1277895,
+                // Firefox is replacing newline characters with a space on the
+                // strings that are actually displayed in the dialog box, so we
+                // need to do the same.
+                currentRealmL10nPattern = currentRealmL10nPattern.replace(/\n{1,}/g,' ');
+
                 currentRealmL10nPattern = currentRealmL10nPattern.replace("%2$S","(.+)").replace("%1$S","(.+)");
                 let regEx = new RegExp(currentRealmL10nPattern);
 
@@ -455,6 +461,12 @@ var keeFoxDialogManager = {
                 if (currentProxyL10nPattern.indexOf("%2$S") > currentProxyL10nPattern.indexOf("%1$S"))
                     realmFirst = true;
 
+                // Due to https://bugzilla.mozilla.org/show_bug.cgi?id=1277895,
+                // Firefox is replacing newline characters with a space on the
+                // strings that are actually displayed in the dialog box, so we
+                // need to do the same.
+                currentProxyL10nPattern = currentProxyL10nPattern.replace(/\n{1,}/g,' ');
+
                 currentProxyL10nPattern = currentProxyL10nPattern.replace("%2$S","(.+)").replace("%1$S","(.+)");
                 let regEx = new RegExp(currentProxyL10nPattern);
 
@@ -491,6 +503,12 @@ var keeFoxDialogManager = {
                 {
                     currentProxyL10nPattern = this._promptBundle.GetStringFromName("EnterUserPasswordFor");
                 }
+
+                // Due to https://bugzilla.mozilla.org/show_bug.cgi?id=1277895,
+                // Firefox is replacing newline characters with a space on the
+                // strings that are actually displayed in the dialog box, so we
+                // need to do the same.
+                currentProxyL10nPattern = currentProxyL10nPattern.replace(/\n{1,}/g,' ');
 
                 currentProxyL10nPattern = currentProxyL10nPattern.replace("%1$S","(.+)");
                 let regEx = new RegExp(currentProxyL10nPattern);


### PR DESCRIPTION
As part of the "fix" for https://bugzilla.mozilla.org/show_bug.cgi?id=1277895,
Firefox is stripping newline characters from localizations before displaying
the text. So, this copies the newline stripping code so that we are matching
what Firefox is actuall displaying rather than what is in the string resource.

Fixes #736